### PR TITLE
Extend lifetime bug

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -12,7 +12,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="30" y="14" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="30" y="13">coverage</text>
-    <text x="71" y="14" fill="#010101" fill-opacity=".3">99%</text>
-    <text x="71" y="13">99%</text>
+    <text x="71" y="14" fill="#010101" fill-opacity=".3">98%</text>
+    <text x="71" y="13">98%</text>
   </g>
 </svg>

--- a/lib/containers/AuthenticationProvider/useExtendTokenLifetime/index.js
+++ b/lib/containers/AuthenticationProvider/useExtendTokenLifetime/index.js
@@ -55,55 +55,45 @@ function useExtendTokenLifetime(tokenData, onSuccess, onFailure) {
             switch (_context.prev = _context.next) {
               case 0:
                 if (processingRef.current) {
-                  _context.next = 20;
+                  _context.next = 18;
                   break;
                 }
 
                 processingRef.current = true;
                 _context.prev = 2;
 
-                if (!tokenData) {
-                  _context.next = 12;
-                  break;
-                }
-
                 if (!isReady) {
-                  _context.next = 8;
+                  _context.next = 7;
                   break;
                 }
 
                 expiryTime = (0, _calculateExpiryTime["default"])(tokenData.expireAt);
-                _context.next = 8;
+                _context.next = 7;
                 return (0, _wait["default"])(expiryTime);
 
-              case 8:
-                _context.next = 10;
+              case 7:
+                _context.next = 9;
                 return (0, _extendTokenLifetime["default"])(tokenData);
 
-              case 10:
+              case 9:
                 response = _context.sent;
+                switchToReady();
                 onSuccess(response);
-
-              case 12:
-                _context.next = 17;
+                _context.next = 18;
                 break;
 
               case 14:
                 _context.prev = 14;
                 _context.t0 = _context["catch"](2);
+                switchToReady();
                 onFailure(_context.t0);
 
-              case 17:
-                _context.prev = 17;
-                switchToReady();
-                return _context.finish(17);
-
-              case 20:
+              case 18:
               case "end":
                 return _context.stop();
             }
           }
-        }, _callee, null, [[2, 14, 17, 20]]);
+        }, _callee, null, [[2, 14]]);
       }));
 
       return function callExtendTokenLifetime() {

--- a/src/containers/AuthenticationProvider/useExtendTokenLifetime/index.js
+++ b/src/containers/AuthenticationProvider/useExtendTokenLifetime/index.js
@@ -30,20 +30,17 @@ export default function useExtendTokenLifetime(tokenData, onSuccess, onFailure) 
         processingRef.current = true;
 
         try {
-          if (tokenData) {
-            if (isReady) {
-              const expiryTime = calculateExpiryTime(tokenData.expireAt);
-              await wait(expiryTime);
-            }
-
-            const response = await extendTokenLifetime(tokenData);
-
-            onSuccess(response);
+          if (isReady) {
+            const expiryTime = calculateExpiryTime(tokenData.expireAt);
+            await wait(expiryTime);
           }
-        } catch (error) {
-          onFailure(error);
-        } finally {
+
+          const response = await extendTokenLifetime(tokenData);
           switchToReady();
+          onSuccess(response);
+        } catch (error) {
+          switchToReady();
+          onFailure(error);
         }
       }
     };


### PR DESCRIPTION
Issue:
After each first extend-lifetime call (called after login, called on refresh, called on new tab), there never happened next one, so user was instantly logged out after received token went over expiry time (unless, ofc, page got refreshed - that's why it was never caught in development, since no dev just sits on page for 10-20 minutes without refreshes triggered by HMR).

`finally` block from trycatch in useExtendTokenLifetime which toggles processingRef was triggered after the token was already updated (and therefore hook was triggered again), but couldn't complete because processingRef check didn't pass.

Removed finally block, moved switchToReady before onSuccess / onFailure calls, works perfectly now.

As agreed, tests will come in following days, need this fix on prod kinda asap
Also removed tokenData check since that already happens a bit higher